### PR TITLE
EPC Read Menu Fixes

### DIFF
--- a/simultaneous_rfid_reader/.gitignore
+++ b/simultaneous_rfid_reader/.gitignore
@@ -1,0 +1,7 @@
+dist/*
+.vscode
+.clang-format
+.clangd
+.editorconfig
+.env
+.ufbt

--- a/simultaneous_rfid_reader/structures.h
+++ b/simultaneous_rfid_reader/structures.h
@@ -309,6 +309,7 @@ typedef struct {
     FuriString* Crc;
     uint32_t ScrollOffset;
     char* ScrollingText;
+    bool IsScrolling;
 } UHFReaderConfigModel;
 
 //Model for the write screen

--- a/simultaneous_rfid_reader/views/view_about.c
+++ b/simultaneous_rfid_reader/views/view_about.c
@@ -78,6 +78,7 @@ void view_about_alloc(UHFReaderApp* App) {
         " The read menu has the following options:\n"
         "- Press Ok to start/stop reading\n"
         "- Press Up to save the selected EPC\n"
+        "- Hold Up to pause scrolling the selected EPC\n"
         "- Press Down to see TID, EPC, User, and Reserved Memory\n"
         "- Press Left/Right to cycle through tags read (M6E & M7E Only)\n\n");
     

--- a/simultaneous_rfid_reader/views/view_config.c
+++ b/simultaneous_rfid_reader/views/view_config.c
@@ -28,8 +28,8 @@ void view_config_alloc(UHFReaderApp* App) {
     //Initializing configuration setting variables
     App->Setting1Values[0] = 1;
     App->Setting1Values[1] = 2;
-    App->Setting1Names[0] = "Connect";
-    App->Setting1Names[1] = "Disconnect";
+    App->Setting1Names[0] = "Disconnected";
+    App->Setting1Names[1] = "Connected";
     App->ReaderConnected = false;
     App->Setting1ConfigLabel = "Connection";
     App->Setting2ConfigLabel = "Power Level";


### PR DESCRIPTION
In this PR, I have changed the read menu to allow the user to press down the up arrow and pause the EPC that is scrolling on the screen. Additionally, I have changed the labels for the connection setting in the config menu. It will display `Disconnected` when the external reader is disconnected and `Connected` if connected. 

In future PRs, I will address some bugs with reading. For now, please use a baud rate of `384000`, as this appears to work without crashing during my most recent testing. 

